### PR TITLE
Improve no-std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.79"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-crossbeam-utils = "0.8.4"
+crossbeam-utils = { version = "0.8.4", default-features = false }
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
At the moment, while ringbuffer-spsc's code is no-std, it's not possible to use it as such because `crossbeam-utils` has `std` as a default feature; this PR adds `default-features = false` for `crossbeam-utils`.